### PR TITLE
docs: fix simple typo, enviroments -> environments

### DIFF
--- a/server/modules/bot/chrome_passwords.py
+++ b/server/modules/bot/chrome_passwords.py
@@ -131,7 +131,7 @@ def chrome_db(chrome_data, content_type):
 
 def utfout(inputvar):
     """
-    Cleans a variable for UTF8 encoding on some enviroments
+    Cleans a variable for UTF8 encoding on some environments
     where python will break with an error
     :credit: koconder
 


### PR DESCRIPTION
There is a small typo in server/modules/bot/chrome_passwords.py.

Should read `environments` rather than `enviroments`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md